### PR TITLE
Add Gazebo simulation plug-in for Hesai XT-32 lidar

### DIFF
--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -16,13 +16,13 @@
    limitations under the License.
 -->
 
-  <xacro:macro name="hesai_pandar_xt_gazebo" params="lidar_frame:=pandar topic_name=/hesai/pandar
+  <xacro:macro name="hesai_xt_gazebo" params="lidar_frame:=pandar topic_name=/hesai/pandar
                min_range:=0.4 max_range:=80.0 min_horizontal_angle:=-180.0 max_horizontal_angle:=180.0
                min_vertical_angle:=-16.0 max_vertical_angle:=15.0 hz:=10 samples:=2000 lasers:=32
                collision_range:=0.3 noise:=0.008 visualize:=false">
 
     <gazebo reference="${lidar_frame}">
-      <sensor type="ray" name="hesai_pandar_xt-VLP">
+      <sensor type="ray" name="hesai_xt_sensor">
         <pose>0 0 0 0 0 0</pose>
         <visualize>${visualize}</visualize>
         <update_rate>${hz}</update_rate>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+<!-- Copyright 2022 University of Oxford
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+  <xacro:macro name="hesai_pandar_xt_gazebo" params="lidar_frame:=pandar topic_name=/hesai/pandar
+               min_range:=0.4 max_range:=80.0 min_horizontal_angle:=-180.0 max_horizontal_angle:=180.0
+               min_vertical_angle:=-16.0 max_vertical_angle:=15.0 hz:=10 samples:=2000 lasers:=32
+               collision_range:=0.3 noise:=0.008 gpu:=false">
+
+    <gazebo reference="${lidar_frame}">
+      <sensor type="ray" name="hesai_pandar_xt-VLP">
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>${hz}</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>${samples}</samples>
+              <resolution>1</resolution>
+              <min_angle>${min_horizontal_angle*pi/180.0}</min_angle>
+              <max_angle>${max_horizontal_angle*pi/180.0}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>${lasers}</samples>
+              <resolution>1</resolution>
+              <min_angle>${min_vertical_angle*pi/180.0}</min_angle>
+              <max_angle>${max_vertical_angle*pi/180.0}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${collision_range}</min>
+            <max>${max_range+1}</max>
+            <resolution>0.001</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.0</stddev>
+          </noise>
+        </ray>
+        <plugin name="gazebo_ros_laser_controller" filename="libgazebo_ros_velodyne_laser.so">
+          <topicName>${topic_name}</topicName>
+          <frameName>${lidar_frame}</frameName> 
+          <min_range>${min_range}</min_range>
+          <max_range>${max_range}</max_range>
+          <gaussianNoise>${noise}</gaussianNoise>
+        </plugin>
+      </sensor>
+    </gazebo>
+  </xacro:macro>
+
+</robot>

--- a/urdf/gazebo.xacro
+++ b/urdf/gazebo.xacro
@@ -19,12 +19,12 @@
   <xacro:macro name="hesai_pandar_xt_gazebo" params="lidar_frame:=pandar topic_name=/hesai/pandar
                min_range:=0.4 max_range:=80.0 min_horizontal_angle:=-180.0 max_horizontal_angle:=180.0
                min_vertical_angle:=-16.0 max_vertical_angle:=15.0 hz:=10 samples:=2000 lasers:=32
-               collision_range:=0.3 noise:=0.008 gpu:=false">
+               collision_range:=0.3 noise:=0.008 visualize:=false">
 
     <gazebo reference="${lidar_frame}">
       <sensor type="ray" name="hesai_pandar_xt-VLP">
         <pose>0 0 0 0 0 0</pose>
-        <visualize>false</visualize>
+        <visualize>${visualize}</visualize>
         <update_rate>${hz}</update_rate>
         <ray>
           <scan>

--- a/urdf/hesai.urdf.xacro
+++ b/urdf/hesai.urdf.xacro
@@ -61,7 +61,13 @@
     <child link="${lidar_frame}" />
   </joint>
 
-  <!-- TODO implement gazebo plugin loading if simulation is true -->
+  <xacro:if value="${simulation}">
+    <xacro:include filename="$(find hesai_description)/urdf/gazebo.xacro"/>
+    <xacro:hesai_pandar_xt_gazebo lidar_frame="${lidar_frame}" topic_name="/hesai/pandar" min_range="0.4" max_range="80.0" 
+      min_horizontal_angle="-180.0" max_horizontal_angle="180.0" min_vertical_angle="-16.0" max_vertical_angle="15.0"
+      hz="10" samples="2000" lasers="32" collision_range="0.3" noise="0.008"
+    />
+  </xacro:if>
 </xacro:macro>
 
 </robot>

--- a/urdf/hesai.urdf.xacro
+++ b/urdf/hesai.urdf.xacro
@@ -63,7 +63,7 @@
 
   <xacro:if value="${simulation}">
     <xacro:include filename="$(find hesai_description)/urdf/gazebo.xacro"/>
-    <xacro:hesai_pandar_xt_gazebo lidar_frame="${lidar_frame}" topic_name="/hesai/pandar" min_range="0.4" max_range="80.0" 
+    <xacro:hesai_xt_gazebo lidar_frame="${lidar_frame}" topic_name="/hesai/pandar" min_range="0.4" max_range="80.0" 
       min_horizontal_angle="-180.0" max_horizontal_angle="180.0" min_vertical_angle="-16.0" max_vertical_angle="15.0"
       hz="10" samples="2000" lasers="32" collision_range="0.3" noise="0.008"
     />


### PR DESCRIPTION
This commit adds the **lidar Gazebo simulation plug-in** to the URDF of Hesai PandarXT (similar to the Ouster simulation in `frontier_description` by @mmattamala in https://github.com/ori-drs/frontier_description/pull/9). The ranges are taken from the Pandar XT-32 [brochure](https://www.oxts.com/wp-content/uploads/2021/01/Hesai-PandarXT32_Brochure.pdf) and [user manual](https://www.hesaitech.com/downloads/#xt32-16).

In order to test it launch the Hesai with the simulation flag set to true `$ roslaunch hesai_description view_urdf.launch simulation:=true`, launch Gazebo with `roslaunch gazebo_ros mud_world.launch` and finally spawn the model into Gazebo with `$ rosrun gazebo_ros spawn_model -urdf -param /robot_description -model hesai`. Finally add the lidar topic in Rviz.

Here a small preview of what this looks like:


https://github.com/ori-drs/hesai_description/assets/53856473/0234c867-1a10-4129-8806-8100d7627bec

