### PR TITLE
Add optional tf prefix

### DIFF
--- a/launch/load.launch
+++ b/launch/load.launch
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <launch>
+  <arg name="prefix" default="" />
   <arg name="simulation" default="false" />
   <arg name="use_gpu" default="true" />
   <arg name="model" default="$(find hesai_description)/urdf/hesai_qt64_standalone.urdf.xacro" />
 
-  <param name="robot_description" command="xacro $(arg model) simulation:=$(arg simulation) use_gpu:=$(arg use_gpu)" />
+  <param name="robot_description" command="xacro $(arg model) prefix:=$(arg prefix) simulation:=$(arg simulation) use_gpu:=$(arg use_gpu)" />
 </launch>

--- a/launch/view_urdf.launch
+++ b/launch/view_urdf.launch
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="rviz" default="true" />
+  <arg name="prefix" default="" />
   <arg name="simulation" default="true" />
   <arg name="use_gpu" default="true" />
 
   <include file="$(find hesai_description)/launch/load.launch">
+    <arg name="prefix" value="$(arg prefix)"/>
     <arg name="simulation" value="$(arg simulation)"/>
     <arg name="use_gpu" value="$(arg use_gpu)"/>
   </include>

--- a/urdf/gazebo.urdf.xacro
+++ b/urdf/gazebo.urdf.xacro
@@ -16,7 +16,7 @@
    limitations under the License.
 -->
 
-  <xacro:macro name="hesai_gazebo" params="lidar_frame:=pandar topic_name=/hesai/pandar
+  <xacro:macro name="hesai_gazebo" params="prefix lidar_frame:=pandar topic_name=/hesai/pandar
                min_range:=0.4 max_range:=80.0 min_horizontal_angle:=-180.0 max_horizontal_angle:=180.0
                min_vertical_angle:=-16.0 max_vertical_angle:=15.0 hz:=10 samples:=2000 lasers:=32
                collision_range:=0.3 noise:=0.008 visualize:=false use_gpu:=true">
@@ -31,7 +31,7 @@
         <xacro:property name="laser_plugin" value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
 
-      <sensor type="${ray_type}" name="hesai_sensor">
+      <sensor type="${ray_type}" name="${prefix}hesai_sensor">
         <pose>0 0 0 0 0 0</pose>
         <visualize>${visualize}</visualize>
         <update_rate>${hz}</update_rate>
@@ -62,7 +62,7 @@
           </noise>
         </ray>
         
-        <plugin name="gazebo_ros_laser_controller" filename="${laser_plugin}">
+        <plugin name="${prefix}gazebo_ros_laser_controller" filename="${laser_plugin}">
           <topicName>${topic_name}</topicName>
           <frameName>${lidar_frame}</frameName> 
           <min_range>${min_range}</min_range>

--- a/urdf/hesai_qt64.urdf.xacro
+++ b/urdf/hesai_qt64.urdf.xacro
@@ -21,13 +21,15 @@
 <xacro:arg name="simulation" default="false"/>
 <xacro:arg name="use_gpu" default="true"/>
 
-<xacro:macro name="hesai_qt64_device" params="parent *origin name:=pandar_xt32_lidar simulation:=false lidar_frame:=pandar use_gpu:=true">
-  <joint name="${parent}_to_hesai" type="fixed">
+<xacro:macro name="hesai_qt64_device" params="parent *origin prefix:='' name:=pandar_qt64_lidar
+                                              topic_name:=/hesai/pandar
+                                              simulation:=false lidar_frame:=pandar use_gpu:=true">
+  <joint name="${parent}_to_${prefix}hesai" type="fixed">
     <xacro:insert_block name="origin"/>
     <parent link="${parent}" />
-    <child link="hesai_base" />
+    <child link="${prefix}hesai_base" />
   </joint>
-  <link name="hesai_base">
+  <link name="${prefix}hesai_base">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <!-- If mesh is not available: -->
@@ -54,17 +56,17 @@
     </collision>
   </link>
   <link name="${lidar_frame}"/>
-  <joint name="hesai_base_to_pandar" type="fixed">
+  <joint name="${prefix}hesai_base_to_pandar" type="fixed">
     <!-- See page 12 of QT64 User Manual -->
     <!-- note that the X axis points left. See manual page 11 -->
     <origin xyz="0.0 0.0 50.4e-3" rpy="0.0 0.0 ${pi/2}"/>
-    <parent link="hesai_base"/>
+    <parent link="${prefix}hesai_base"/>
     <child link="${lidar_frame}" />
   </joint>
 
   <xacro:if value="${simulation}">
     <xacro:include filename="$(find hesai_description)/urdf/gazebo.urdf.xacro"/>
-    <xacro:hesai_gazebo lidar_frame="${lidar_frame}" topic_name="/hesai/pandar" min_range="0.1" max_range="20.0" 
+    <xacro:hesai_gazebo prefix="${prefix}" lidar_frame="${lidar_frame}" topic_name="${topic_name}" min_range="0.1" max_range="20.0" 
       min_horizontal_angle="-180.0" max_horizontal_angle="180.0" min_vertical_angle="-52.1" max_vertical_angle="52.1"
       hz="10" samples="600" lasers="64" collision_range="0.3" noise="0.008" use_gpu="${use_gpu}"
     />

--- a/urdf/hesai_qt64_standalone.urdf.xacro
+++ b/urdf/hesai_qt64_standalone.urdf.xacro
@@ -16,13 +16,16 @@
 
 <robot name="hesai" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find hesai_description)/urdf/hesai_qt64.urdf.xacro" />
+  <xacro:arg name="prefix" default="" />
   <xacro:arg name="simulation" default="false" />
   <xacro:arg name="use_gpu" default="true" />
 
   <!-- Dummy link  -->
   <link name="base"/>
 
-  <xacro:hesai_qt64_device parent="base" simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
+  <xacro:hesai_qt64_device parent="base" prefix="$(arg prefix)"
+    lidar_frame="$(arg prefix)pandar"
+    simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:hesai_qt64_device>
 </robot>

--- a/urdf/hesai_xt32.urdf.xacro
+++ b/urdf/hesai_xt32.urdf.xacro
@@ -21,13 +21,15 @@
 <xacro:arg name="simulation" default="false" />
 <xacro:arg name="use_gpu" default="true"/>
 
-<xacro:macro name="hesai_xt32_device" params="parent *origin name:=pandar_xt32_lidar simulation:=false lidar_frame:=pandar use_gpu:=true">
-  <joint name="${parent}_to_hesai" type="fixed">
+<xacro:macro name="hesai_xt32_device" params="parent *origin prefix:='' name:=pandar_xt32_lidar
+                                              topic_name:=/hesai/pandar
+                                              simulation:=false lidar_frame:=pandar use_gpu:=true">
+  <joint name="${parent}_to_${prefix}hesai" type="fixed">
     <xacro:insert_block name="origin"/>
     <parent link="${parent}" />
-    <child link="hesai_base" />
+    <child link="${prefix}hesai_base" />
   </joint>
-  <link name="hesai_base">
+  <link name="${prefix}hesai_base">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <!-- If mesh is not available: -->
@@ -54,17 +56,17 @@
     </collision>
   </link>
   <link name="${lidar_frame}"/>
-  <joint name="hesai_base_to_pandar" type="fixed">
+  <joint name="${prefix}hesai_base_to_pandar" type="fixed">
     <!-- See page 12 of XT64 User Manual -->
     <!-- note that the X axis points left. See manual page 11 -->
     <origin xyz="0.0 0.0 46.4e-3" rpy="0.0 0.0 ${pi/2}"/>
-    <parent link="hesai_base"/>
+    <parent link="${prefix}hesai_base"/>
     <child link="${lidar_frame}" />
   </joint>
 
   <xacro:if value="${simulation}">
     <xacro:include filename="$(find hesai_description)/urdf/gazebo.urdf.xacro"/>
-    <xacro:hesai_gazebo lidar_frame="${lidar_frame}" topic_name="/hesai/pandar" min_range="0.4" max_range="80.0" 
+    <xacro:hesai_gazebo prefix="${prefix}" lidar_frame="${lidar_frame}" topic_name="${topic_name}" min_range="0.4" max_range="80.0" 
       min_horizontal_angle="-180.0" max_horizontal_angle="180.0" min_vertical_angle="-16.0" max_vertical_angle="15.0"
       hz="10" samples="2000" lasers="32" collision_range="0.3" noise="0.008" use_gpu="${use_gpu}"
     />

--- a/urdf/hesai_xt32_standalone.urdf.xacro
+++ b/urdf/hesai_xt32_standalone.urdf.xacro
@@ -16,13 +16,16 @@
 
 <robot name="hesai" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find hesai_description)/urdf/hesai_xt32.urdf.xacro" />
+  <xacro:arg name="prefix" default="" />
   <xacro:arg name="simulation" default="false" />
   <xacro:arg name="use_gpu" default="true" />
 
   <!-- Dummy link  -->
   <link name="base"/>
 
-  <xacro:hesai_xt32_device parent="base" simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
+  <xacro:hesai_xt32_device parent="base" prefix="$(arg prefix)"
+    lidar_frame="$(arg prefix)pandar"
+    simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:hesai_xt32_device>
 </robot>


### PR DESCRIPTION
This pull request adds an **optional tf prefix `prefix`** to the Hesai URDF (defaults to an empty string). This way multiple Hesai lidars can be included into the same URDF. E.g. the following URDF uses the prefix `second_` for the second Hesai that is mounted at an angle.

![Frankenstein Frontier preview](https://github.com/ori-drs/hesai_description/assets/53856473/30e9c89e-2e63-4800-ac2b-32dda14d44e8)

The URDF structure for the [URDF above](https://github.com/ori-drs/frankenstein_frontier.git) is the following (`$ check_urdf <(xacro frankenstein_frontier.urdf.xacro)`):

```
robot name is: frankenstein_frontier
---------- Successfully Parsed XML ---------------
root Link: base_link has 2 child(ren)
    child(1):  frontier_baseplate
        child(1):  lidar_mount_1
        child(2):  lidar_mount_2
            child(1):  second_lidar
                child(1):  second_hesai_base
                    child(1):  second_pandar
        child(3):  mast
    child(2):  frontier_mount
        child(1):  cam_front_link
        child(2):  cam_left_link
        child(3):  cam_right_link
        child(4):  hesai_base
            child(1):  pandar
        child(5):  alphasense_imu
            child(1):  cam_front_optical_frame
            child(2):  cam_left_optical_frame
            child(3):  cam_right_optical_frame
        child(6):  frontier_base
```