### PR TITLE
Add support for Gazebo Classic simulation

### DIFF
--- a/launch/description.launch.py
+++ b/launch/description.launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
     default_xacro_file = PathJoinSubstitution(
         [
             get_package_share_directory('hesai_description'),
-            'urdf', 'hesai_xt32_standalone.urdf.xacro'
+            'urdf', 'hesai_qt64_standalone.urdf.xacro'
         ]
     )
     xacro_file_parameter_arg = DeclareLaunchArgument(

--- a/launch/visualize.launch.py
+++ b/launch/visualize.launch.py
@@ -10,12 +10,23 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    simulation_parameter_name = 'simulation'
+    simulation = LaunchConfiguration(simulation_parameter_name)
+
+    simulation_parameter_arg = DeclareLaunchArgument(
+        simulation_parameter_name,
+        default_value='true',
+        description='Simulated or real hardware interface'
+    )
+
     description_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
@@ -26,7 +37,7 @@ def generate_launch_description():
             ]
         ),
         launch_arguments={
-            'simulation': 'true'
+            'simulation': simulation
         }.items(),
     )
 
@@ -41,7 +52,30 @@ def generate_launch_description():
         arguments=['--display-config', rviz_file]
     )
 
+    gazebo_node = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    get_package_share_directory('gazebo_ros'),
+                    'launch', 'gazebo.launch.py'
+                )
+            ]
+        ),
+        condition=IfCondition(simulation)
+    )
+    gazebo_spawner_node = Node(
+        package='gazebo_ros',
+        executable='spawn_entity.py',
+        name='gazebo_spawner',
+        arguments=['-entity', 'magnet', '-topic', 'robot_description'],
+        output='screen',
+        condition=IfCondition(simulation)
+    )
+
     ld = LaunchDescription()
+    ld.add_action(simulation_parameter_arg)
     ld.add_action(description_launch)
     ld.add_action(rviz_node)
+    ld.add_action(gazebo_node)
+    ld.add_action(gazebo_spawner_node)
     return ld

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/urdf/gazebo.urdf.xacro
+++ b/urdf/gazebo.urdf.xacro
@@ -4,22 +4,16 @@
   <xacro:macro name="hesai_gazebo" params="prefix lidar_frame:=pandar topic_name=/hesai/pandar
                min_range:=0.4 max_range:=80.0 min_horizontal_angle:=-180.0 max_horizontal_angle:=180.0
                min_vertical_angle:=-16.0 max_vertical_angle:=15.0 hz:=10 samples:=2000 lasers:=32
-               collision_range:=0.3 noise:=0.008 visualize:=false use_gpu:=true">
+               collision_range:=0.3 noise:=0.008 visualize:=false">
 
     <gazebo reference="${lidar_frame}">
-      <xacro:if value="${use_gpu}">
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="laser_plugin" value="libgazebo_ros_velodyne_gpu_laser.so" />
-      </xacro:if>
-      <xacro:unless value="${use_gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="laser_plugin" value="libgazebo_ros_velodyne_laser.so" />
-      </xacro:unless>
-
-      <sensor type="${ray_type}" name="${prefix}hesai_sensor">
-        <pose>0 0 0 0 0 0</pose>
-        <visualize>${visualize}</visualize>
+      <sensor name="${prefix}hesai_sensor" type="lidar">
         <update_rate>${hz}</update_rate>
+        <visualize>${visualize}</visualize>
+        <always_on>true</always_on>
+        <ignition_frame_id>${lidar_frame}</ignition_frame_id>
+        <topic>${topic_name}</topic>
+        <!-- 'ray' for Gazebo Classic, 'lidar' for Ignition -->
         <ray>
           <scan>
             <horizontal>
@@ -38,16 +32,14 @@
           <range>
             <min>${collision_range}</min>
             <max>${max_range+1}</max>
-            <resolution>0.001</resolution>
+            <resolution>0.01</resolution>
           </range>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.0</stddev>
-          </noise>
         </ray>
-        
-        <plugin name="${prefix}gazebo_ros_laser_controller" filename="${laser_plugin}">
+
+        <plugin name="${prefix}gazebo_ros_laser_controller" filename="libgazebo_ros_velodyne_laser.so">
+          <ros>
+            <remapping>~/out:=${topic_name}</remapping>
+          </ros>
           <topicName>${topic_name}</topicName>
           <frameName>${lidar_frame}</frameName> 
           <min_range>${min_range}</min_range>

--- a/urdf/hesai_qt64.urdf.xacro
+++ b/urdf/hesai_qt64.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="hesai_qt64" params="parent *origin prefix:='' name:=pandar_qt64
                                          topic_name:=/hesai/pandar
-                                         simulation:=false lidar_frame:=pandar use_gpu:=true">
+                                         simulation:=false lidar_frame:=pandar">
     <joint name="${parent}_to_${prefix}hesai" type="fixed">
       <xacro:insert_block name="origin"/>
       <parent link="${parent}" />
@@ -43,7 +43,7 @@
       <xacro:include filename="$(find hesai_description)/urdf/gazebo.urdf.xacro"/>
       <xacro:hesai_gazebo prefix="${prefix}" lidar_frame="${lidar_frame}" topic_name="${topic_name}" min_range="0.1" max_range="20.0" 
         min_horizontal_angle="-180.0" max_horizontal_angle="180.0" min_vertical_angle="-52.1" max_vertical_angle="52.1"
-        hz="10" samples="600" lasers="64" collision_range="0.3" noise="0.008" use_gpu="${use_gpu}"
+        hz="10" samples="600" lasers="64" collision_range="0.3" noise="0.008"
       />
     </xacro:if>
   </xacro:macro>

--- a/urdf/hesai_qt64_standalone.urdf.xacro
+++ b/urdf/hesai_qt64_standalone.urdf.xacro
@@ -3,14 +3,13 @@
 
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="simulation" default="false" />
-  <xacro:arg name="use_gpu" default="true" />
 
   <xacro:include filename="$(find hesai_description)/urdf/hesai_qt64.urdf.xacro" />
 
   <link name="base"/>
 
   <xacro:hesai_qt64 parent="base" prefix="$(arg prefix)" lidar_frame="$(arg prefix)pandar"
-                    simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
+                    simulation="$(arg simulation)" >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:hesai_qt64>
 

--- a/urdf/hesai_xt32.urdf.xacro
+++ b/urdf/hesai_xt32.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="hesai_xt32" params="parent *origin prefix:='' name:=hesai_xt32
                                         topic_name:=/hesai/pandar
-                                        simulation:=false lidar_frame:=pandar use_gpu:=true">
+                                        simulation:=false lidar_frame:=pandar">
     <joint name="${parent}_to_${prefix}hesai" type="fixed">
       <xacro:insert_block name="origin"/>
       <parent link="${parent}" />
@@ -44,7 +44,7 @@
       <xacro:include filename="$(find hesai_description)/urdf/gazebo.urdf.xacro"/>
       <xacro:hesai_gazebo prefix="${prefix}" lidar_frame="${lidar_frame}" topic_name="${topic_name}" min_range="0.4" max_range="80.0" 
         min_horizontal_angle="-180.0" max_horizontal_angle="180.0" min_vertical_angle="-16.0" max_vertical_angle="15.0"
-        hz="10" samples="2000" lasers="32" collision_range="0.3" noise="0.008" use_gpu="${use_gpu}"
+        hz="10" samples="2000" lasers="32" collision_range="0.3" noise="0.008"
       />
     </xacro:if>
   </xacro:macro>

--- a/urdf/hesai_xt32_standalone.urdf.xacro
+++ b/urdf/hesai_xt32_standalone.urdf.xacro
@@ -3,14 +3,13 @@
 
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="simulation" default="false" />
-  <xacro:arg name="use_gpu" default="true" />
 
   <xacro:include filename="$(find hesai_description)/urdf/hesai_xt32.urdf.xacro" />
 
   <link name="base"/>
 
   <xacro:hesai_xt32 parent="base" prefix="$(arg prefix)" lidar_frame="$(arg prefix)pandar"
-                    simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
+                    simulation="$(arg simulation)" >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:hesai_xt32>
 


### PR DESCRIPTION
This pull request adds support for **simulation of the 3D lidar with [Gazebo Classic](https://classic.gazebosim.org/)**. The syntax for sensor plug-ins in [Ignition Gazebo](https://gazebosim.org/docs/latest/sensors/) is slightly different and I will have to adapt the URDF to work with it. There seems to be no obvious way of supporting both.
You can test this pull request by running:

```
$ rosdep install --from-paths src --ignore-src -r
$ ros2 launch magnet_description visualize.launch.py
```
and finally visualizing the lidar topic `/hesai/pandar`:

![Gazebo Classic](https://github.com/user-attachments/assets/a22fc73e-161c-4140-bbb0-0c85c4dc8355)

