### PR TITLE
Replace pandar frame with hesai_lidar frame

### DIFF
--- a/rviz/model.rviz
+++ b/rviz/model.rviz
@@ -72,7 +72,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        pandar:
+        hesai_lidar:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -93,7 +93,7 @@ Visualization Manager:
           Value: true
         hesai_base:
           Value: true
-        pandar:
+        hesai_lidar:
           Value: true
       Marker Scale: 0.5
       Name: TF
@@ -103,7 +103,7 @@ Visualization Manager:
       Tree:
         base:
           hesai_base:
-            pandar:
+            hesai_lidar:
               {}
       Update Interval: 0
       Value: true

--- a/urdf/gazebo.urdf.xacro
+++ b/urdf/gazebo.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="hesai_gazebo" params="prefix lidar_frame:=pandar topic_name=/hesai/pandar
+  <xacro:macro name="hesai_gazebo" params="prefix lidar_frame:=hesai_lidar topic_name=/hesai/pandar
                min_range:=0.4 max_range:=80.0 min_horizontal_angle:=-180.0 max_horizontal_angle:=180.0
                min_vertical_angle:=-16.0 max_vertical_angle:=15.0 hz:=10 samples:=2000 lasers:=32
                collision_range:=0.3 noise:=0.008 visualize:=false use_gpu:=true">

--- a/urdf/hesai_qt64.urdf.xacro
+++ b/urdf/hesai_qt64.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <robot name="hesai_qt64" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="hesai_qt64" params="parent *origin prefix:='' name:=pandar_qt64
+  <xacro:macro name="hesai_qt64" params="parent *origin prefix:='' name:=hesai_lidar_qt64
                                          topic_name:=/hesai/pandar
-                                         simulation:=false lidar_frame:=pandar use_gpu:=true">
+                                         simulation:=false lidar_frame:=hesai_lidar use_gpu:=true">
     <joint name="${parent}_to_${prefix}hesai" type="fixed">
       <xacro:insert_block name="origin"/>
       <parent link="${parent}" />

--- a/urdf/hesai_qt64.urdf.xacro
+++ b/urdf/hesai_qt64.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="hesai_qt64" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="hesai_qt64" params="parent *origin prefix:='' name:=hesai_lidar_qt64
+  <xacro:macro name="hesai_qt64" params="parent *origin prefix:='' name:=pandar_qt64
                                          topic_name:=/hesai/pandar
                                          simulation:=false lidar_frame:=hesai_lidar use_gpu:=true">
     <joint name="${parent}_to_${prefix}hesai" type="fixed">

--- a/urdf/hesai_qt64_standalone.urdf.xacro
+++ b/urdf/hesai_qt64_standalone.urdf.xacro
@@ -9,7 +9,7 @@
 
   <link name="base"/>
 
-  <xacro:hesai_qt64 parent="base" prefix="$(arg prefix)" lidar_frame="$(arg prefix)pandar"
+  <xacro:hesai_qt64 parent="base" prefix="$(arg prefix)" lidar_frame="$(arg prefix)hesai_lidar"
                     simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:hesai_qt64>

--- a/urdf/hesai_xt32.urdf.xacro
+++ b/urdf/hesai_xt32.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="hesai_xt32" params="parent *origin prefix:='' name:=hesai_xt32
                                         topic_name:=/hesai/pandar
-                                        simulation:=false lidar_frame:=pandar use_gpu:=true">
+                                        simulation:=false lidar_frame:=hesai_lidar use_gpu:=true">
     <joint name="${parent}_to_${prefix}hesai" type="fixed">
       <xacro:insert_block name="origin"/>
       <parent link="${parent}" />

--- a/urdf/hesai_xt32_standalone.urdf.xacro
+++ b/urdf/hesai_xt32_standalone.urdf.xacro
@@ -9,7 +9,7 @@
 
   <link name="base"/>
 
-  <xacro:hesai_xt32 parent="base" prefix="$(arg prefix)" lidar_frame="$(arg prefix)pandar"
+  <xacro:hesai_xt32 parent="base" prefix="$(arg prefix)" lidar_frame="$(arg prefix)hesai_lidar"
                     simulation="$(arg simulation)" use_gpu="$(arg use_gpu)" >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:hesai_xt32>


### PR DESCRIPTION
Update `pandar` frame name to match the new default `hesai_lidar` used by ros2 hesai driver - https://github.com/HesaiTechnology/HesaiLidar_ROS_2.0/blob/0f5a1be9babea453c74bd1a9ede1e64272e036da/config/config.yaml#L68 .